### PR TITLE
Grouping products by batch_id

### DIFF
--- a/app/models/spree/import_source_file.rb
+++ b/app/models/spree/import_source_file.rb
@@ -73,7 +73,7 @@ class Spree::ImportSourceFile < ActiveRecord::Base
 
       importer.import :taxonomy
 
-      importer.import :product
+      importer.import :product, batch_id: id
       importer.import :variant
     end
 

--- a/app/models/spree/import_source_file.rb
+++ b/app/models/spree/import_source_file.rb
@@ -74,7 +74,7 @@ class Spree::ImportSourceFile < ActiveRecord::Base
       importer.import :taxonomy
 
       importer.import :product, batch_id: id
-      importer.import :variant
+      importer.import :variant, batch_id: id
     end
 
     self.import_warnings  = importer.warnings

--- a/db/migrate/20131226185146_add_batch_id_to_product.rb
+++ b/db/migrate/20131226185146_add_batch_id_to_product.rb
@@ -1,0 +1,6 @@
+class AddBatchIdToProduct < ActiveRecord::Migration
+  def change
+    add_column :spree_products, :batch_id, :integer
+    add_index :spree_products, :batch_id
+  end
+end

--- a/db/migrate/20131230201855_add_batch_id_to_variant.rb
+++ b/db/migrate/20131230201855_add_batch_id_to_variant.rb
@@ -1,0 +1,6 @@
+class AddBatchIdToVariant < ActiveRecord::Migration
+  def change
+    add_column :spree_variants, :batch_id, :integer
+    add_index :spree_variants, :batch_id
+  end
+end

--- a/lib/spree_importer/importers/product.rb
+++ b/lib/spree_importer/importers/product.rb
@@ -3,6 +3,8 @@ module SpreeImporter
     class Product
       include SpreeImporter::Importers::Base
 
+      attr_accessor :batch_id
+
       row_based
 
       import_attributes :sku_pattern, :sku, :name, :price, :available_on,
@@ -18,6 +20,8 @@ module SpreeImporter
           master_sku             = val headers, row, "master_sku"
           product.sku            = master_sku unless master_sku.nil?
           product.sku_pattern  ||= SpreeImporter.config.default_sku
+
+          product.batch_id = self.batch_id
 
           if ::Spree::Variant.exists? sku: product.sku
             self.warnings << "Product exists for sku #{product.sku}, skipping product import"

--- a/lib/spree_importer/importers/product.rb
+++ b/lib/spree_importer/importers/product.rb
@@ -21,7 +21,8 @@ module SpreeImporter
           product.sku            = master_sku unless master_sku.nil?
           product.sku_pattern  ||= SpreeImporter.config.default_sku
 
-          product.batch_id = self.batch_id
+          product.batch_id = self.batch_id # tie to a certain batch import
+          product.master.batch_id = self.batch_id
 
           if ::Spree::Variant.exists? sku: product.sku
             self.warnings << "Product exists for sku #{product.sku}, skipping product import"

--- a/lib/spree_importer/importers/variant.rb
+++ b/lib/spree_importer/importers/variant.rb
@@ -3,6 +3,8 @@ module SpreeImporter
     class Variant
       include SpreeImporter::Importers::Base
 
+      attr_accessor :batch_id
+
       row_based
 
       import_attributes :sku
@@ -24,6 +26,8 @@ module SpreeImporter
               end
             end
           end
+
+          instance.batch_id = self.batch_id # tie to a certain batch import
 
           instance.save! # create stock item
           stock_headers(headers, row) do |location, value|

--- a/spec/helpers/csv_helper.rb
+++ b/spec/helpers/csv_helper.rb
@@ -6,7 +6,9 @@ def get_importer(path)
 end
 
 def get_import_source_file(path)
-  Spree::ImportSourceFile.new data: File.read(csv_path(path))
+  isf = Spree::ImportSourceFile.new data: File.read(csv_path(path))
+  isf.id = 999
+  isf
 end
 
 def csv_path(path)

--- a/spec/lib/spree_importer/importers/product_spec.rb
+++ b/spec/lib/spree_importer/importers/product_spec.rb
@@ -16,6 +16,14 @@ describe SpreeImporter::Importers::Product do
     end
   end
 
+  it 'should set :batch_id on instances' do
+    base      = get_importer "gin-lane-product-list"
+    instances = base.import :product, {batch_id: 668}
+    instances.each do |i|
+      i.batch_id.should == 668
+    end
+  end
+
   it "should throw an exception for a badlly formatted date string" do
     csv      = CSV.parse "available_on\ninvalidate", headers: true
     headers  = { "available_on" => SpreeImporter::Field.new("available_on", headers: true, index: 0) }

--- a/spec/lib/spree_importer/importers/variant_spec.rb
+++ b/spec/lib/spree_importer/importers/variant_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe SpreeImporter::Importers::Variant do
+  it 'should set :batch_id on instances' do
+    import_source_file = get_import_source_file "gin-lane-variant-export"
+    import_source_file.import!
+    variant         = Spree::Variant.find_by_sku "STN-FW13-DUMMY-NO-SIZE"
+
+    variant.batch_id.should == 999 
+  end
+
   it "should import stock items in the proper quantity" do
     import_source_file = get_import_source_file "gin-lane-variant-export"
     import_source_file.import!


### PR DESCRIPTION
Hey!

This will explicitly group products originating from the same ImportSourceFile. Which, in turn, will allow us to extend the ImportSourceFile#show interface to add buttons to perform operations on all of the resulting records. 

Will be useful for synchronizing with a remote API in batches, such as the Lightspeed API. 

Cheers
