### PR TITLE
Alter class interpolation syntax for Deface

### DIFF
--- a/app/views/spree/admin/import_source_files/show.html.haml
+++ b/app/views/spree/admin/import_source_files/show.html.haml
@@ -20,6 +20,6 @@
       %th
         = h.raw
   - @resource.each do |row|
-    %tr{ class: cycle("even", "odd") }
+    %tr( class="#{cycle 'even', 'odd'}" )
       - @resource.headers.each do |_,h|
         %td= truncate row[h.raw]


### PR DESCRIPTION
Heyyo,

Does not change anything about the output, but uses an alternative syntax. This is needed because Deface seems to have a certain HAML parsing bug. 

Easy merge :clap: 
