### PR TITLE
Alter class interpolation syntax for Deface

### DIFF
--- a/app/views/spree/admin/import_source_files/show.html.haml
+++ b/app/views/spree/admin/import_source_files/show.html.haml
@@ -20,6 +20,7 @@
       %th
         = h.raw
   - @resource.each do |row|
-    %tr{ class: cycle("even", "odd") }
+    - clazz = cycle('even', 'odd')
+    %tr{ class: clazz}
       - @resource.headers.each do |_,h|
         %td= truncate row[h.raw]


### PR DESCRIPTION
Second attempt. 

Deface has trouble decorating other extensions' haml views. This sidesteps the HTML class interpolation, and the world is a good place again.

Otherwise we get naaaaastay stuff like this

```
Haml::SyntaxError ((haml):23: syntax error, unexpected tIDENTIFIER, expecting ')'
...class" => "#cycle('even', "data-erb-odd" => "<%= )" %>")}>\n...
...                               ^
(haml):23: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
... "#cycle('even', "data-erb-odd" => "<%= )" %>")}>\n    <% @r...
...                               ^
(haml):23: syntax error, unexpected tIDENTIFIER, expecting tSTRING_DEND
...h| %>\n    <td>    <%= truncate row[h.raw] %>\n</td>\n    <%...
...                               ^
(haml):23: syntax error, unexpected '>'
...>    <%= truncate row[h.raw] %>\n</td>\n    <% end %>\n  </t...
...                               ^
(haml):23: unknown regexp options - tr
(haml):23: syntax error, unexpected $undefined
...n</td>\n    <% end %>\n  </tr>\n  <% end %>\n</table>\n", 0,...
...                               ^
(haml):23: syntax error, unexpected '>'
...<% end %>\n  </tr>\n  <% end %>\n</table>\n", 0, false);;::H...
...                               ^
(haml):23: unterminated regexp meets end of file
(haml):23: syntax error, unexpected end-of-input, expecting tSTRING_DEND
...::Haml::Util.html_safe(_erbout)
...                               ^):

```
