### PR TITLE
Variant Grouping Bugfix

### DIFF
--- a/app/models/spree/import_source_file.rb
+++ b/app/models/spree/import_source_file.rb
@@ -7,6 +7,7 @@ class Spree::ImportSourceFile < ActiveRecord::Base
   serialize :imported_records
 
   has_many :products, foreign_key: :batch_id
+  has_many :variants, foreign_key: :batch_id
 
   default_scope -> {
     order "created_at desc"

--- a/app/models/spree/import_source_file.rb
+++ b/app/models/spree/import_source_file.rb
@@ -6,6 +6,8 @@ class Spree::ImportSourceFile < ActiveRecord::Base
   serialize :import_errors
   serialize :imported_records
 
+  has_many :products, foreign_key: :batch_id
+
   default_scope -> {
     order "created_at desc"
   }

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,5 +1,8 @@
 module Spree
   Product.class_eval do
+
+    belongs_to :import_source_file, foreign_key: :batch_id
+
     def set_sku(variant)
       pattern         = sku_pattern.blank?? SpreeImporter.config.default_sku : sku_pattern
       options         = variant.option_values.map {|v| [ v.option_type.name, v ] }

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,6 +1,8 @@
 Spree::Variant.class_eval do
   delegate_belongs_to :product, :properties, :property, :option_types, :taxons, :sku_pattern
 
+  belongs_to :import_source_file, foreign_key: :batch_id
+
   def master_sku
     is_master?? sku : product.master.sku
   end

--- a/lib/spree_importer/importers/product.rb
+++ b/lib/spree_importer/importers/product.rb
@@ -87,6 +87,7 @@ module SpreeImporter
 
         product.save!
         product.variants.each &:generate_sku!
+        product.variants.each{|v| v.batch_id = batch_id }
       end
     end
 

--- a/spec/lib/spree_importer/importers/product_spec.rb
+++ b/spec/lib/spree_importer/importers/product_spec.rb
@@ -21,6 +21,9 @@ describe SpreeImporter::Importers::Product do
     instances = base.import :product, {batch_id: 668}
     instances.each do |i|
       i.batch_id.should == 668
+      i.variants.each do |v|
+        v.batch_id.should == v.batch_id
+      end
     end
   end
 

--- a/spec/lib/spree_importer/importers/variant_spec.rb
+++ b/spec/lib/spree_importer/importers/variant_spec.rb
@@ -4,9 +4,12 @@ describe SpreeImporter::Importers::Variant do
   it 'should set :batch_id on instances' do
     import_source_file = get_import_source_file "gin-lane-variant-export"
     import_source_file.import!
-    variant         = Spree::Variant.find_by_sku "STN-FW13-DUMMY-NO-SIZE"
 
-    variant.batch_id.should == 999 
+    master         = Spree::Variant.find_by_sku "STN-FW13-DUMMY-NO-SIZE"
+    master.batch_id.should == 999
+    master.product.variants.each do |v|
+      v.batch_id.should == 999
+    end
   end
 
   it "should import stock items in the proper quantity" do


### PR DESCRIPTION
(Includes our proper duplex AR relations; closing other outstanding PR since this one is cumulative.)

This fixes variants not having batch_id set if they were generated using the option_types instead of by the explicit row-based strategy. 
